### PR TITLE
Omit fields from transformModelToGraphQLTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ export const { objectTypes, enumTypes } =
 export const UserType = objectTypes.UserType;
 ```
 
+Use options.omitFields to specify which model fields will be ignored.
+
+```typescript
+const { enumTypes, objectTypes } = transformModelToGraphQLTypes(
+  MessageRuleModel,
+  { omitFields: ['time'] }
+);
+```
+
 #### `createInputTypeFromOutputType()`
 
 Converts an output GraphQL type to an input type for mutations.


### PR DESCRIPTION
Add `options.omitFiedls: string[]` parameter to `transformModelToGraphQLTypes`

If the original model has graphql-invalid data structures (e.g. enums containing numbers like "01:00") `transformModelToGraphQLTypes` will fail to create them. One may overcome this situation by omitting this field and manually adding the desired field later on as a custom graphql field.