### PR TITLE
Upgrade target TS version

### DIFF
--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "es2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "libReplacement": true,                           /* Enable lib replacement. */


### PR DESCRIPTION
Underlying projects may be using methods like:
- Object.prototype.hasOwn() (ECMAScript 2022)
- String.prototype.replaceAll() (ECMAScript 2021)

Our typechecking is based on ECMAScript 2020, although our node version is compatible with ECMAScript 2022.
Thus, TS mistakenly thinks that the methods above are not defined, when they are actually used and running as expected.

The solution is to just upgrade the target version of the typechecking, as introduced by this PR